### PR TITLE
Upgrade faraday dependency to 2.x

### DIFF
--- a/alegra.gemspec
+++ b/alegra.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_dependency 'faraday', '~> 0.17.0'
+  spec.add_dependency 'faraday', '>= 1.0', '< 3'
   spec.add_development_dependency 'jazz_fingers', '~> 5.0'
   spec.add_dependency 'json', '~> 2.2'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/lib/alegra/request.rb
+++ b/lib/alegra/request.rb
@@ -6,7 +6,9 @@ module Alegra
     def initialize(host, path, token = nil)
       @token = token
       @path = path
-      @session = Faraday.new url: host
+      @session = Faraday.new(url: host) do |conn|
+        conn.adapter :net_http
+      end
     end
 
     def get(url, attrs = {}, options = { format: :formated })


### PR DESCRIPTION
## Summary
- Update faraday dependency from `~> 0.17.0` to `>= 1.0, < 3`
- Add explicit `:net_http` adapter in `Faraday.new` block (required by faraday 2.x)

## Why
Faraday 0.17.6 produces 50+ frozen string deprecation warnings on Ruby 3.4. Upgrading to faraday 2.x resolves these warnings and keeps the gem compatible with modern Ruby.

## Changes
- `alegra.gemspec`: Relaxed faraday version constraint
- `lib/alegra/request.rb`: Added explicit adapter configuration (`conn.adapter :net_http`)

The request/response interface (`req.url`, `req.headers`, `req.body`, `response.status`, `response.body`) is fully compatible between faraday 0.17 and 2.x — no other code changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)